### PR TITLE
Mejoras visuales en selector de fecha y feature de préstamos

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -81,6 +81,7 @@
   padding: 2rem;
   margin-bottom: 2rem;
   transition: all 0.3s ease;
+  overflow: visible !important;
 }
 
 .section-header {

--- a/src/components/ObjectChange/ObjectChangeForm.css
+++ b/src/components/ObjectChange/ObjectChangeForm.css
@@ -119,6 +119,20 @@
   margin-left: 0.5rem;
 }
 
+.info-prestado {
+  background: #e3f2fd;
+  color: #1976d2;
+  border-left: 4px solid #1976d2;
+  padding: 0.3em 0.7em;
+  border-radius: 6px;
+  margin-bottom: 0.7em;
+  font-size: 0.97em;
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+  max-width: 350px;
+}
+
 @keyframes slideIn {
   from {
     opacity: 0;
@@ -136,4 +150,56 @@
 
 .fade-in {
   animation: slideIn 0.3s ease-out;
+}
+
+.switch-label {
+  display: flex;
+  align-items: center;
+  font-size: 1em;
+  font-weight: 500;
+  color: #1976d2;
+  gap: 0.5em;
+}
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+}
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: .3s;
+  border-radius: 24px;
+}
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  transition: .3s;
+  border-radius: 50%;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.12);
+}
+input:checked + .slider {
+  background-color: #1976d2;
+}
+input:checked + .slider:before {
+  transform: translateX(20px);
+}
+.slider.round {
+  border-radius: 24px;
 }

--- a/src/components/ObjectChange/ObjectChangeForm.jsx
+++ b/src/components/ObjectChange/ObjectChangeForm.jsx
@@ -16,11 +16,12 @@ function ObjectChangeForm() {
   
   const [successMessage, setSuccessMessage] = useState('');
   const [showOtherField, setShowOtherField] = useState(false);
+  const [isPrestado, setIsPrestado] = useState(false);
   
   
   const locationsArc = ['Administración', 'Ventas', 'Fijacion', 'Calidad', 'Herramientas','Empaque','Almacen','Pernos','Trefilacion','Mantenimiento'];
-  const locationsExt = ['Empaque', 'Prensa', 'Espectometro', 'Extrusion', 'Despachos', 'Rimax', 'Estañado','Matriceria'];
-  const objectTypes = ['Teléfono', 'Mousepad', 'Pantalla', 'Garra de Pantalla', 'Teclado', 'Mouse', 'Otro'];
+  const locationsExt = ['Administración', 'Empaque', 'Prensa', 'Espectometro', 'Extrusion', 'Despachos', 'Rimax', 'Estañado','Matriceria'];
+  const objectTypes = ['Teléfono', 'Mousepad', 'Pantalla', 'Garra de Pantalla', 'Teclado', 'Mouse', 'Audífonos', 'Otro'];
   
   
   const getLocationsForCompany = () => {
@@ -55,6 +56,10 @@ function ObjectChangeForm() {
     });
   };
   
+  const handlePrestadoChange = (e) => {
+    setIsPrestado(e.target.checked);
+  };
+  
   const handleSubmit = (e) => {
     e.preventDefault();
     
@@ -63,6 +68,12 @@ function ObjectChangeForm() {
       objectType: formData.objectType === 'Otro' ? formData.otherObject : formData.objectType,
       timestamp: new Date().toISOString()
     };
+    if (isPrestado) {
+      changeData.estado = 'Prestado';
+      changeData.fechaPrestamo = new Date().toISOString();
+      changeData.fechaDevolucion = null;
+      changeData.diasPrestado = null;
+    }
     
     addObjectChange(changeData);
     
@@ -81,6 +92,7 @@ function ObjectChangeForm() {
       date: new Date().toISOString().split('T')[0]
     });
     setShowOtherField(false);
+    setIsPrestado(false);
   };
   
   
@@ -198,6 +210,20 @@ function ObjectChangeForm() {
             />
           </div>
         )}
+        
+        <div className="form-group">
+          <label className="switch-label">
+            <span style={{ marginRight: 12 }}>¿Este objeto es un préstamo?</span>
+            <span className="switch">
+              <input
+                type="checkbox"
+                checked={isPrestado}
+                onChange={handlePrestadoChange}
+              />
+              <span className="slider round"></span>
+            </span>
+          </label>
+        </div>
         
         <DatePickerField
           label="Fecha"

--- a/src/components/ObjectChange/ObjectChangeList.css
+++ b/src/components/ObjectChange/ObjectChangeList.css
@@ -4,7 +4,7 @@
   background-color: white;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-  overflow: hidden;
+  overflow: visible;
 }
 
 .list-header {

--- a/src/components/ObjectChange/ObjectChangeList.css
+++ b/src/components/ObjectChange/ObjectChangeList.css
@@ -135,3 +135,69 @@
   color: white;
   border-color: var(--primary);
 }
+
+.estado-btn {
+  border: none;
+  border-radius: 16px;
+  padding: 0.4em 1em;
+  font-weight: 600;
+  font-size: 0.95em;
+  transition: background 0.2s, color 0.2s;
+  outline: none;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.3em;
+}
+
+.estado-btn.prestado {
+  background: #e3f2fd;
+  color: #1976d2;
+}
+
+.estado-btn.devuelto {
+  background: #e8f5e9;
+  color: #388e3c;
+  padding: 0.2em 0.7em;
+  font-size: 0.85em;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2em;
+  min-width: unset;
+  height: 2em;
+}
+
+.estado-btn.sin-estado {
+  background: #f3f3f3;
+  color: #b0b0b0;
+  border-radius: 12px;
+  padding: 0.2em 0.7em;
+  font-size: 0.92em;
+  font-weight: 400;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+  border: 1px dashed #d0d0d0;
+  min-width: unset;
+  height: 2em;
+}
+
+.estado-btn:disabled {
+  opacity: 0.6;
+}
+
+.estado-tooltip {
+  background: #222;
+  color: #fff;
+  padding: 0.5em 1em;
+  border-radius: 8px;
+  font-size: 0.95em;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.35), 0 0 0 2px #fff2 inset;
+  pointer-events: none;
+  white-space: nowrap;
+  max-width: 350px;
+  z-index: 9999 !important;
+  position: fixed;
+  border: 1.5px solid #1976d2;
+}

--- a/src/components/ObjectChange/ObjectChangeList.jsx
+++ b/src/components/ObjectChange/ObjectChangeList.jsx
@@ -1,13 +1,29 @@
 import React, { useState, useEffect } from 'react';
 import './ObjectChangeList.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { getObjectChanges, exportToExcel, importFromExcel } from '../../data/objectChangesStore';
+import { getObjectChanges, exportToExcel, importFromExcel, toggleEstadoObjectChange } from '../../data/objectChangesStore';
 import DataImportExport from '../common/DataImportExport';
+import { faExchangeAlt, faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+import ReactDOM from 'react-dom';
+
+function diasDesde(fecha) {
+  if (!fecha) return 0;
+  const ahora = new Date();
+  const inicio = new Date(fecha);
+  return Math.max(1, Math.round((ahora - inicio) / (1000 * 60 * 60 * 24)));
+}
+
+function formatFecha(fecha) {
+  if (!fecha) return '-';
+  const d = new Date(fecha);
+  return d.toLocaleDateString();
+}
 
 function ObjectChangeList() {
   const [objectChanges, setObjectChanges] = useState([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [isReadOnly, setIsReadOnly] = useState(false);
+  const [tooltip, setTooltip] = useState({ visible: false, x: 0, y: 0, text: '' });
   
   useEffect(() => {
     
@@ -53,7 +69,27 @@ function ObjectChangeList() {
       )
     : objectChanges;
   
-  
+  const handleToggleEstado = async (id) => {
+    await toggleEstadoObjectChange(id);
+    const data = await getObjectChanges();
+    setObjectChanges(data);
+  };
+
+  const handleMouseOver = (e, change) => {
+    let text = '';
+    if (change.estado === 'Prestado') {
+      const dias = diasDesde(change.fechaPrestamo);
+      text = `Prestado desde ${formatFecha(change.fechaPrestamo)} (${dias} día${dias > 1 ? 's' : ''})`;
+    } else if (change.estado === 'Devuelto') {
+      text = `Prestado del ${formatFecha(change.fechaPrestamo)} al ${formatFecha(change.fechaDevolucion)} (${change.diasPrestado || 1} día${(change.diasPrestado || 1) > 1 ? 's' : ''})`;
+    }
+    setTooltip({ visible: true, x: e.clientX, y: e.clientY, text });
+  };
+
+  const handleMouseOut = () => {
+    setTooltip({ ...tooltip, visible: false });
+  };
+
   return (
     <div className="object-change-list">
       <div className="list-header">
@@ -91,6 +127,9 @@ function ObjectChangeList() {
             <th>
               <FontAwesomeIcon icon={['fas', 'calendar-alt']} /> Fecha
             </th>
+            <th>
+              <FontAwesomeIcon icon={faExchangeAlt} /> Estado
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -100,11 +139,52 @@ function ObjectChangeList() {
               <td>{change.personName || '-'}</td>
               <td>{change.objectType}</td>
               <td>{new Date(change.date).toLocaleDateString()}</td>
+              <td>
+                {change.estado === 'Prestado' ? (
+                  <button
+                    className={`estado-btn prestado`}
+                    onClick={() => handleToggleEstado(change.id)}
+                    onMouseOver={e => handleMouseOver(e, change)}
+                    onMouseMove={e => handleMouseOver(e, change)}
+                    onMouseOut={handleMouseOut}
+                    disabled={isReadOnly}
+                    style={{ cursor: isReadOnly ? 'not-allowed' : 'pointer' }}
+                  >
+                    <FontAwesomeIcon icon={faInfoCircle} style={{ marginRight: 6 }} />
+                    <FontAwesomeIcon icon={["fas", "hand-holding"]} style={{ marginRight: 4, color: '#1976d2' }} />
+                    Marcar como Devuelto
+                  </button>
+                ) : change.estado === 'Devuelto' ? (
+                  <span
+                    className="estado-btn devuelto"
+                    onMouseOver={e => handleMouseOver(e, change)}
+                    onMouseMove={e => handleMouseOver(e, change)}
+                    onMouseOut={handleMouseOut}
+                    style={{ cursor: 'default', userSelect: 'none' }}
+                  >
+                    <FontAwesomeIcon icon={faInfoCircle} style={{ marginRight: 6 }} />
+                    Devuelto
+                  </span>
+                ) : (
+                  <span className="estado-btn sin-estado">
+                    <FontAwesomeIcon icon={faInfoCircle} style={{ marginRight: 6, color: '#b0b0b0' }} />
+                    <span style={{ color: '#b0b0b0', fontStyle: 'italic' }}>Sin estado</span>
+                  </span>
+                )}
+              </td>
             </tr>
           ))}
         </tbody>
       </table>
-      
+      {tooltip.visible && ReactDOM.createPortal(
+        <div
+          className="estado-tooltip"
+          style={{ position: 'fixed', left: tooltip.x + 16, top: tooltip.y + 8, zIndex: 99999 }}
+        >
+          {tooltip.text}
+        </div>,
+        document.body
+      )}
       {filteredChanges.length > 10 && (
         <div className="pagination">
           <button><FontAwesomeIcon icon={['fas', 'chevron-left']} /></button>

--- a/src/components/common/DatePickerField.css
+++ b/src/components/common/DatePickerField.css
@@ -91,6 +91,7 @@
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
   border-radius: 8px;
   overflow: hidden;
+  z-index: 99999 !important;
 }
 
 .react-datepicker__header {

--- a/src/components/common/DatePickerField.jsx
+++ b/src/components/common/DatePickerField.jsx
@@ -92,6 +92,7 @@ const DatePickerField = ({
           showMonthDropdown
           dropdownMode="select"
           popperProps={{ strategy: 'fixed' }}
+          popperPlacement="top-end"
         />
         <button
           type="button"

--- a/src/components/common/DatePickerField.jsx
+++ b/src/components/common/DatePickerField.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import DatePicker, { registerLocale } from 'react-datepicker';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import es from 'date-fns/locale/es';
@@ -21,7 +21,7 @@ const DatePickerField = ({
   yearDropdownItemNumber = 30,
   helpText 
 }) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const datePickerRef = useRef(null);
 
   
   let dateValue = null;
@@ -61,7 +61,9 @@ const DatePickerField = ({
   };
 
   const handleClick = () => {
-    setIsOpen(!isOpen);
+    if (datePickerRef.current && datePickerRef.current.setOpen) {
+      datePickerRef.current.setOpen(true);
+    }
   };
 
   return (
@@ -74,10 +76,9 @@ const DatePickerField = ({
       
       <div className="date-picker-container">
         <DatePicker
+          ref={datePickerRef}
           selected={dateValue}
           onChange={handleChange}
-          onClickOutside={() => setIsOpen(false)}
-          open={isOpen}
           locale="es"
           dateFormat="dd/MM/yyyy"
           className="enhanced-input date-input"
@@ -90,6 +91,7 @@ const DatePickerField = ({
           yearDropdownItemNumber={yearDropdownItemNumber}
           showMonthDropdown
           dropdownMode="select"
+          popperProps={{ strategy: 'fixed' }}
         />
         <button
           type="button"


### PR DESCRIPTION
El calendario del selector de fecha ahora se despliega arriba a la derecha del campo, evitando ser cortado por el contenedor.
Se ajustó el CSS de los contenedores para permitir el desborde de popovers y mejorar la experiencia visual.
Se implementó la lógica y UI para marcar objetos como préstamo desde el formulario, con visualización clara en la lista.
Soluciona problemas de recorte y superposición en formularios y listas.